### PR TITLE
pin node to 16 or 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "supertest": "^6.2.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^16 || ^18"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     ]
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16 || ^18"
   },
   "type": "module",
   "stylelint": {


### PR DESCRIPTION
Change copied from govuk-prototype-rig, newer versions of node were causing build failures.